### PR TITLE
Massage fan speed to existing enum values

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bskzephyr"
-version = "1.0.2"
+version = "1.0.3"
 description = "Asynchronous library to control BSK Zephyr heat recovery devices using BSK Connect APIs."
 readme = "README.md"
 authors = [

--- a/src/bskzephyr/__init__.py
+++ b/src/bskzephyr/__init__.py
@@ -96,6 +96,20 @@ class BSKZephyrClient:
             else:
                 raise ZephyrException(resp.status)
 
+    def massage_fan_speed(self, speed: int) -> int:
+        try:
+            FanSpeed(speed)
+            return speed
+        except ValueError:
+            if speed >= FanSpeed.high:
+                return FanSpeed.high.value
+            elif speed >= FanSpeed.medium:
+                return FanSpeed.medium.value
+            elif speed >= FanSpeed.low:
+                return FanSpeed.low.value
+            else:
+                return FanSpeed.night.value
+
     async def list_devices(self) -> list[DeviceUser]:
         try:
             resp: ClientResponse = await self._aiohttp_session.request(
@@ -108,6 +122,9 @@ class BSKZephyrClient:
             resp = await resp.json()
             models = []
             for device in resp:
+                device["device"]["fanSpeed"] = self.massage_fan_speed(
+                    device["device"]["fanSpeed"]
+                )
                 models.append(DeviceUser(**device))
 
             return models

--- a/uv.lock
+++ b/uv.lock
@@ -136,7 +136,7 @@ wheels = [
 
 [[package]]
 name = "bskzephyr"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Firmware updates to the mini seem to have added different speeds, so be more tolerant of different speeds, whilst still mapping them to the existing selects.
Ref: https://github.com/andersonshatch/hass-bskzephyr/issues/18